### PR TITLE
Fixes Empty markdown file generation and formatting due to colon use in argument block

### DIFF
--- a/src/lazydocs/_about.py
+++ b/src/lazydocs/_about.py
@@ -1,5 +1,5 @@
 """Information about this library. This file will automatically changed."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 # __author__
 # __email__

--- a/src/lazydocs/generation.py
+++ b/src/lazydocs/generation.py
@@ -220,7 +220,7 @@ def to_md_file(
         return
 
     md_file = filename
-    
+
     if is_mdx:
         if not filename.endswith(".mdx"):
             md_file = filename + ".mdx"
@@ -614,7 +614,7 @@ class MarkdownGenerator(object):
         if path:
             if is_mdx:
                 markdown = _MDX_SOURCE_BADGE_TEMPLATE.format(path=path) + markdown
-            else:    
+            else:
                 markdown = _SOURCE_BADGE_TEMPLATE.format(path=path) + markdown
 
         return markdown
@@ -998,8 +998,13 @@ def generate_docs(
                     continue
 
                 try:
-                    mod_spec = loader.find_spec(module_name)
-                    mod = importlib.util.module_from_spec(mod_spec)
+                    try:
+                        mod_spec = loader.find_spec(module_name)
+                        mod = importlib.util.module_from_spec(mod_spec)
+                        mod_spec.loader.exec_module(mod)
+                    except AttributeError:
+                        # For older python version compatibility
+                        mod = loader.find_module(module_name).load_module(module_name)  # type: ignore
                     module_md = generator.module2md(mod, is_mdx=is_mdx)
                     if not module_md:
                         # Module md is empty -> ignore module and all submodules
@@ -1077,8 +1082,13 @@ def generate_docs(
                             continue
 
                         try:
-                            mod_spec = loader.find_spec(module_name)
-                            mod = importlib.util.module_from_spec(mod_spec)
+                            try:
+                                mod_spec = loader.find_spec(module_name)
+                                mod = importlib.util.module_from_spec(mod_spec)
+                                mod_spec.loader.exec_module(mod)
+                            except AttributeError:
+                                # For older python version compatibility
+                                mod = loader.find_module(module_name).load_module(module_name)  # type: ignore
                             module_md = generator.module2md(mod, is_mdx=is_mdx)
 
                             if not module_md:

--- a/src/lazydocs/generation.py
+++ b/src/lazydocs/generation.py
@@ -429,13 +429,16 @@ def _doc2md(obj: Any) -> str:
                 argindent = indent
             elif arg_list and not literal_block and _RE_ARGSTART.match(line):
                 # start of an exception-type block
-                out.append(
-                    "\n"
-                    + " " * blockindent
-                    + " - "
-                    + _RE_ARGSTART.sub(r"<b>`\1`</b>: \2", line)
-                )
-                argindent = indent
+                if indent > argindent:
+                    out.append(" " + line)
+                else:
+                    out.append(
+                        "\n"
+                        + " " * blockindent
+                        + " - "
+                        + _RE_ARGSTART.sub(r"<b>`\1`</b>: \2", line)
+                    )
+                    argindent = indent
             elif indent > argindent:
                 # attach docs text of argument
                 # * (blockindent + 2)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] New Feature
- [x] Feature Improvment
- [ ] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
- Fixes generation of empty markdown files.
    - Caused by previous PR #57, forgetting to call on `mod_spec.loader.exec_module(mod)`
    - Inherently also fixed issue #69
- Fixes incorrect formatting due to the use of colon ":" in argument blocks.
    - Line was not appending to parent argument, but appended on own line

**Checklist:**

- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
