### PR TITLE
Docstring markdown render overhaul (preserves markdown syntax), new features and bugfixes including no find_module AttributeError fix

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/pr-labeler-file-path.yml
           # workaround for problem: https://github.com/wesnoth/wesnoth/commit/958c82d0867568057caaf58356502ec8c87d8366
-          sync-labels: ""
+          sync-labels: false
       - uses: TimonVS/pr-labeler-action@v3
         with:
           configuration-path: .github/pr-labeler-branch-name.yml

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ lazydocs [OPTIONS] PATHS...
 * `--ignored-modules TEXT`: A list of modules that should be ignored.  [default: ]
 * `--watermark / --no-watermark`: If `True`, add a watermark with a timestamp to bottom of the markdown files.  [default: True]
 * `--validate / --no-validate`: If `True`, validate the docstrings via pydocstyle. Requires pydocstyle to be installed.  [default: False]
+* `--output-format TEXT`: The output format for the creation of the markdown files. This may be 'md' or 'mdx'. Defaults to md.
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ lazydocs [OPTIONS] PATHS...
 * `--validate / --no-validate`: If `True`, validate the docstrings via pydocstyle. Requires pydocstyle to be installed.  [default: False]
 * `--output-format TEXT`: The output format for the creation of the markdown files. This may be 'md' or 'mdx'. Defaults to md.
 * `--private-modules / --no-private-modules`: If `True`, includes modules with "_" prefix. [default: False]
+* `--toc / --no-toc`: If `True`, includes table of contents in generated module markdown files. [default: False]
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ lazydocs [OPTIONS] PATHS...
 
 * `--output-path TEXT`: The output path for the creation of the markdown files. Set this to `stdout` to print all markdown to stdout.  [default: ./docs/]
 * `--src-base-url TEXT`: The base repo link used as prefix for all source links. Should also include the branch name.
+* `--url-line-prefix TEXT`: Line prefix for git repository line url anchors #{prefix}line. If None provided, defaults to Github style notation.
 * `--overview-file TEXT`: Filename of overview file. If not provided, no API overview file will be generated.
 * `--remove-package-prefix / --no-remove-package-prefix`: If `True`, the package prefix will be removed from all functions and methods.  [default: True]
 * `--ignored-modules TEXT`: A list of modules that should be ignored.  [default: ]

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ lazydocs [OPTIONS] PATHS...
 * `--watermark / --no-watermark`: If `True`, add a watermark with a timestamp to bottom of the markdown files.  [default: True]
 * `--validate / --no-validate`: If `True`, validate the docstrings via pydocstyle. Requires pydocstyle to be installed.  [default: False]
 * `--output-format TEXT`: The output format for the creation of the markdown files. This may be 'md' or 'mdx'. Defaults to md.
+* `--private-modules / --no-private-modules`: If `True`, includes modules with "_" prefix. [default: False]
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/docs/lazydocs.generation.md
+++ b/docs/lazydocs.generation.md
@@ -1,14 +1,28 @@
 <!-- markdownlint-disable -->
 
-<a href="https://github.com/ml-tooling/lazydocs/blob/main/src/lazydocs/generation.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../src/lazydocs/generation.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 # <kbd>module</kbd> `lazydocs.generation`
-Main module for markdown generation. 
+Main module for markdown generation.
+
+
+## Table of Contents
+- [`MarkdownGenerator`](./lazydocs.generation.md#class-markdowngenerator)
+	- [`__init__`](./lazydocs.generation.md#constructor-__init__)
+	- [`class2md`](./lazydocs.generation.md#method-class2md)
+	- [`func2md`](./lazydocs.generation.md#method-func2md)
+	- [`import2md`](./lazydocs.generation.md#method-import2md)
+	- [`module2md`](./lazydocs.generation.md#method-module2md)
+	- [`overview2md`](./lazydocs.generation.md#method-overview2md)
+	- [`toc2md`](./lazydocs.generation.md#method-toc2md)
+- [`generate_docs`](./lazydocs.generation.md#function-generate_docs)
+- [`to_md_file`](./lazydocs.generation.md#function-to_md_file)
+
 
 
 ---
 
-<a href="https://github.com/ml-tooling/lazydocs/blob/main/src/lazydocs/generation.py#L197"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../src/lazydocs/generation.py#L223"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 ## <kbd>function</kbd> `to_md_file`
 
@@ -18,26 +32,28 @@ to_md_file(
     filename: str,
     out_path: str = '.',
     watermark: bool = True,
-    disable_markdownlint: bool = True
+    disable_markdownlint: bool = True,
+    is_mdx: bool = False
 ) → None
 ```
 
-Creates an API docs file from a provided text. 
-
+Creates an API docs file from a provided text.
 
 
 **Args:**
- 
- - <b>`markdown_str`</b> (str):  Markdown string with line breaks to write to file. 
- - <b>`filename`</b> (str):  Filename without the .md 
- - <b>`watermark`</b> (bool):  If `True`, add a watermark with a timestamp to bottom of the markdown files. 
- - <b>`disable_markdownlint`</b> (bool):  If `True`, an inline tag is added to disable markdownlint for this file. 
- - <b>`out_path`</b> (str):  The output directory 
+
+- <b>`markdown_str`</b> (str): Markdown string with line breaks to write to file.
+- <b>`filename`</b> (str): Filename without the .md
+- <b>`out_path`</b> (str): The output directory.
+- <b>`watermark`</b> (bool): If `True`, add a watermark with a timestamp to bottom of the markdown files.
+- <b>`disable_markdownlint`</b> (bool): If `True`, an inline tag is added to disable markdownlint for this file.
+- <b>`is_mdx`</b> (bool, optional): JSX support. Default to False.
+
 
 
 ---
 
-<a href="https://github.com/ml-tooling/lazydocs/blob/main/src/lazydocs/generation.py#L889"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../src/lazydocs/generation.py#L1158"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 ## <kbd>function</kbd> `generate_docs`
 
@@ -49,173 +65,225 @@ generate_docs(
     src_base_url: Optional[str] = None,
     remove_package_prefix: bool = False,
     ignored_modules: Optional[List[str]] = None,
+    output_format: Optional[str] = None,
     overview_file: Optional[str] = None,
     watermark: bool = True,
-    validate: bool = False
+    validate: bool = False,
+    private_modules: bool = False,
+    include_toc: bool = False,
+    url_line_prefix: Optional[str] = None
 ) → None
 ```
 
-Generates markdown documentation for provided paths based on Google-style docstrings. 
-
+Generates markdown documentation for provided paths based on Google-style docstrings.
 
 
 **Args:**
- 
- - <b>`paths`</b>:  Selected paths or import name for markdown generation. 
- - <b>`output_path`</b>:  The output path for the creation of the markdown files. Set this to `stdout` to print all markdown to stdout. 
- - <b>`src_root_path`</b>:  The root folder name containing all the sources. Fallback to git repo root. 
- - <b>`src_base_url`</b>:  The base url of the github link. Should include branch name. All source links are generated with this prefix. 
- - <b>`remove_package_prefix`</b>:  If `True`, the package prefix will be removed from all functions and methods. 
- - <b>`ignored_modules`</b>:  A list of modules that should be ignored. 
- - <b>`overview_file`</b>:  Filename of overview file. If not provided, no overview file will be generated. 
- - <b>`watermark`</b>:  If `True`, add a watermark with a timestamp to bottom of the markdown files. 
- - <b>`validate`</b>:  If `True`, validate the docstrings via pydocstyle. Requires pydocstyle to be installed. 
+
+- <b>`paths`</b>: Selected paths or import name for markdown generation.
+- <b>`output_path`</b>: The output path for the creation of the markdown files. Set this to `stdout` to print all markdown to stdout.
+- <b>`src_root_path`</b>: The root folder name containing all the sources. Fallback to git repo root.
+- <b>`src_base_url`</b>: The base url of the github link. Should include branch name. All source links are generated with this prefix.
+- <b>`remove_package_prefix`</b>: If `True`, the package prefix will be removed from all functions and methods.
+- <b>`ignored_modules`</b>: A list of modules that should be ignored.
+- <b>`output_format`</b>: Markdown file extension and format.
+- <b>`overview_file`</b>: Filename of overview file. If not provided, no overview file will be generated.
+- <b>`watermark`</b>: If `True`, add a watermark with a timestamp to bottom of the markdown files.
+- <b>`validate`</b>: If `True`, validate the docstrings via pydocstyle. Requires pydocstyle to be installed.
+- <b>`private_modules`</b>: If `True`, includes modules with `_` prefix.
+- <b>`url_line_prefix: Line prefix for git repository line url anchors. Default`</b>: None - github "L".
+
 
 
 ---
 
-<a href="https://github.com/ml-tooling/lazydocs/blob/main/src/lazydocs/generation.py#L454"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../src/lazydocs/generation.py#L627"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 ## <kbd>class</kbd> `MarkdownGenerator`
-Markdown generator class. 
+Markdown generator class.
 
-<a href="https://github.com/ml-tooling/lazydocs/blob/main/src/lazydocs/generation.py#L457"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
-### <kbd>method</kbd> `__init__`
+<a href="../src/lazydocs/generation.py#L630"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>constructor</kbd> `__init__`
 
 ```python
-__init__(
+MarkdownGenerator(
     src_root_path: Optional[str] = None,
     src_base_url: Optional[str] = None,
-    remove_package_prefix: bool = False
+    remove_package_prefix: bool = False,
+    url_line_prefix: Optional[str] = None
 )
 ```
 
-Initializes the markdown API generator. 
-
+Initializes the markdown API generator.
 
 
 **Args:**
- 
- - <b>`src_root_path`</b>:  The root folder name containing all the sources. 
- - <b>`src_base_url`</b>:  The base github link. Should include branch name.  All source links are generated with this prefix. 
- - <b>`remove_package_prefix`</b>:  If `True`, the package prefix will be removed from all functions and methods. 
+
+- <b>`src_root_path`</b>: The root folder name containing all the sources.
+- <b>`src_base_url`</b>: The base github link. Should include branch name.
+    All source links are generated with this prefix.
+- <b>`remove_package_prefix`</b>: If `True`, the package prefix will be removed from all functions and methods.
+- <b>`url_line_prefix: Line prefix for git repository line url anchors. Default`</b>: None - github "L".
+
 
 
 
 
 ---
 
-<a href="https://github.com/ml-tooling/lazydocs/blob/main/src/lazydocs/generation.py#L609"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../src/lazydocs/generation.py#L795"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 ### <kbd>method</kbd> `class2md`
 
 ```python
-class2md(cls: Any, depth: int = 2) → str
+class2md(cls: Any, depth: int = 2, is_mdx: bool = False) → str
 ```
 
-Takes a class and creates markdown text to document its methods and variables. 
-
+Takes a class and creates markdown text to document its methods and variables.
 
 
 **Args:**
- 
- - <b>`cls`</b> (class):  Selected class for markdown generation. 
- - <b>`depth`</b> (int, optional):  Number of # to append to function name. Defaults to 2. 
 
+- <b>`cls`</b> (class): Selected class for markdown generation.
+- <b>`depth`</b> (int, optional): Number of # to append to function name. Defaults to 2.
+- <b>`is_mdx`</b> (bool, optional): JSX support. Default to False.
 
 
 **Returns:**
- 
- - <b>`str`</b>:  Markdown documentation for selected class. 
+
+- <b>`str`</b>: Markdown documentation for selected class.
+
 
 ---
 
-<a href="https://github.com/ml-tooling/lazydocs/blob/main/src/lazydocs/generation.py#L524"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../src/lazydocs/generation.py#L706"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 ### <kbd>method</kbd> `func2md`
 
 ```python
-func2md(func: Callable, clsname: str = '', depth: int = 3) → str
+func2md(
+    func: Callable,
+    clsname: str = '',
+    depth: int = 3,
+    is_mdx: bool = False
+) → str
 ```
 
-Takes a function (or method) and generates markdown docs. 
-
+Takes a function (or method) and generates markdown docs.
 
 
 **Args:**
- 
- - <b>`func`</b> (Callable):  Selected function (or method) for markdown generation. 
- - <b>`clsname`</b> (str, optional):  Class name to prepend to funcname. Defaults to "". 
- - <b>`depth`</b> (int, optional):  Number of # to append to class name. Defaults to 3. 
 
+- <b>`func`</b> (Callable): Selected function (or method) for markdown generation.
+- <b>`clsname`</b> (str, optional): Class name to prepend to funcname. Defaults to "".
+- <b>`depth`</b> (int, optional): Number of # to append to class name. Defaults to 3.
+- <b>`is_mdx`</b> (bool, optional): JSX support. Default to False.
 
 
 **Returns:**
- 
- - <b>`str`</b>:  Markdown documentation for selected function. 
+
+- <b>`str`</b>: Markdown documentation for selected function.
+
 
 ---
 
-<a href="https://github.com/ml-tooling/lazydocs/blob/main/src/lazydocs/generation.py#L815"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../src/lazydocs/generation.py#L1046"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 ### <kbd>method</kbd> `import2md`
 
 ```python
-import2md(obj: Any, depth: int = 1) → str
+import2md(
+    obj: Any,
+    depth: int = 1,
+    is_mdx: bool = False,
+    include_toc: bool = False
+) → str
 ```
 
-Generates markdown documentation for a selected object/import. 
-
+Generates markdown documentation for a selected object/import.
 
 
 **Args:**
- 
- - <b>`obj`</b> (Any):  Selcted object for markdown docs generation. 
- - <b>`depth`</b> (int, optional):  Number of # to append before heading. Defaults to 1. 
 
+- <b>`obj`</b> (Any): Selcted object for markdown docs generation.
+- <b>`depth`</b> (int, optional): Number of # to append before heading. Defaults to 1.
+- <b>`is_mdx`</b> (bool, optional): JSX support. Default to False.
+- <b>`include_toc`</b> (bool, Optional): Include table of contents for module file. Defaults to False.
 
 
 **Returns:**
- 
- - <b>`str`</b>:  Markdown documentation of selected object. 
+
+- <b>`str`</b>: Markdown documentation of selected object.
+
 
 ---
 
-<a href="https://github.com/ml-tooling/lazydocs/blob/main/src/lazydocs/generation.py#L720"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../src/lazydocs/generation.py#L943"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 ### <kbd>method</kbd> `module2md`
 
 ```python
-module2md(module: module, depth: int = 1) → str
+module2md(
+    module: module,
+    depth: int = 1,
+    is_mdx: bool = False,
+    include_toc: bool = False
+) → str
 ```
 
-Takes an imported module object and create a Markdown string containing functions and classes. 
-
+Takes an imported module object and create a Markdown string containing functions and classes.
 
 
 **Args:**
- 
- - <b>`module`</b> (types.ModuleType):  Selected module for markdown generation. 
- - <b>`depth`</b> (int, optional):  Number of # to append before module heading. Defaults to 1. 
 
+- <b>`module`</b> (types.ModuleType): Selected module for markdown generation.
+- <b>`depth`</b> (int, optional): Number of # to append before module heading. Defaults to 1.
+- <b>`is_mdx`</b> (bool, optional): JSX support. Default to False.
+- <b>`include_toc`</b> (bool, optional): Include table of contents in module file. Defaults to False.
 
 
 **Returns:**
- 
- - <b>`str`</b>:  Markdown documentation for selected module. 
+
+- <b>`str`</b>: Markdown documentation for selected module.
+
 
 ---
 
-<a href="https://github.com/ml-tooling/lazydocs/blob/main/src/lazydocs/generation.py#L835"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../src/lazydocs/generation.py#L1068"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 ### <kbd>method</kbd> `overview2md`
 
 ```python
-overview2md() → str
+overview2md(is_mdx: bool = False) → str
 ```
 
-Generates a documentation overview file based on the generated docs. 
+Generates a documentation overview file based on the generated docs.
+
+
+**Args:**
+
+- <b>`is_mdx`</b> (bool, optional): JSX support. Default to False.
+
+
+**Returns:**
+
+- <b>`str`</b>: Markdown documentation of overview file.
+
+
+---
+
+<a href="../src/lazydocs/generation.py#L1137"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `toc2md`
+
+```python
+toc2md(module: module = None, is_mdx: bool = False) → str
+```
+
+Generates table of contents for imported object.
+
 
 
 

--- a/src/lazydocs/_about.py
+++ b/src/lazydocs/_about.py
@@ -1,5 +1,5 @@
 """Information about this library. This file will automatically changed."""
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 # __author__
 # __email__

--- a/src/lazydocs/_cli.py
+++ b/src/lazydocs/_cli.py
@@ -50,6 +50,10 @@ def generate(
         False,
         help="If `True`, all packages starting with `_` will be included.",
     ),
+    toc: bool = typer.Option(
+        False,
+        help="Include table of contents in module file. Defaults to False.",
+    ),
 ) -> None:
     """Generates markdown documentation for your Python project based on Google-style docstrings."""
 
@@ -65,6 +69,7 @@ def generate(
             watermark=watermark,
             validate=validate,
             private_modules=private_modules,
+            include_toc=toc,
         )
     except Exception as ex:
         typer.echo(str(ex))

--- a/src/lazydocs/_cli.py
+++ b/src/lazydocs/_cli.py
@@ -45,8 +45,11 @@ def generate(
     output_format: Optional[str] = typer.Option(
         None,
         help="The output format for the creation of the markdown files. This may be 'md' or 'mdx'. Defaults to md.",
-    )
-        
+    ),
+    private_modules: bool = typer.Option(
+        False,
+        help="If `True`, all packages starting with `_` will be included.",
+    ),
 ) -> None:
     """Generates markdown documentation for your Python project based on Google-style docstrings."""
 
@@ -61,6 +64,7 @@ def generate(
             overview_file=overview_file,
             watermark=watermark,
             validate=validate,
+            private_modules=private_modules,
         )
     except Exception as ex:
         typer.echo(str(ex))

--- a/src/lazydocs/_cli.py
+++ b/src/lazydocs/_cli.py
@@ -54,6 +54,10 @@ def generate(
         False,
         help="Include table of contents in module file. Defaults to False.",
     ),
+    url_line_prefix: Optional[str] = typer.Option(
+        None,
+        help="Line prefix for git repository line url anchors #{prefix}line. If none provided, defaults to Github style notation.",
+    ),
 ) -> None:
     """Generates markdown documentation for your Python project based on Google-style docstrings."""
 
@@ -70,6 +74,7 @@ def generate(
             validate=validate,
             private_modules=private_modules,
             include_toc=toc,
+            url_line_prefix=url_line_prefix,
         )
     except Exception as ex:
         typer.echo(str(ex))

--- a/src/lazydocs/generation.py
+++ b/src/lazydocs/generation.py
@@ -259,7 +259,7 @@ def to_md_file(
         )
 
     print("Writing {}.".format(md_file))
-    with open(os.path.join(out_path, md_file), "w", encoding="utf-8") as f:
+    with open(os.path.join(out_path, md_file), "w", encoding="utf-8", newline="\n") as f:
         f.write(markdown_str)
 
 
@@ -1348,5 +1348,5 @@ def generate_docs(
         # Write mkdocs pages file
         print("Writing mkdocs .pages file.")
         # TODO: generate navigation items to fix problem with naming
-        with open(os.path.join(output_path, ".pages"), "w") as f:
+        with open(os.path.join(output_path, ".pages"),  "w", encoding="utf-8", newline="\n") as f:
             f.write(_MKDOCS_PAGES_TEMPLATE.format(overview_file=overview_file))

--- a/src/lazydocs/generation.py
+++ b/src/lazydocs/generation.py
@@ -9,20 +9,31 @@ import pkgutil
 import re
 import subprocess
 import types
+from dataclasses import dataclass
 from pydoc import locate
 from typing import Any, Callable, Dict, List, Optional
 
 _RE_BLOCKSTART_LIST = re.compile(
-    r"(Args:|Arg:|Arguments:|Parameters:|Kwargs:|Attributes:|Returns:|Yields:|Kwargs:|Raises:).{0,2}$",
+    r"^(Args:|Arg:|Arguments:|Parameters:|Kwargs:|Attributes:|Returns:|Yields:|Kwargs:|Raises:).{0,2}$",
     re.IGNORECASE,
 )
 
-_RE_BLOCKSTART_TEXT = re.compile(r"(Examples:|Example:|Todo:).{0,2}$", re.IGNORECASE)
+_RE_BLOCKSTART_TEXT = re.compile(
+    r"^(Example[s]?:|Todo:|Reference[s]?:).{0,2}$",
+    re.IGNORECASE
+)
 
-_RE_QUOTE_TEXT = re.compile(r"(Notes:|Note:).{0,2}$", re.IGNORECASE)
+# https://github.com/orgs/community/discussions/16925
+# https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
+_RE_ADMONITION_TEXT = re.compile(
+    r"^(?:\[\!?)?(NOTE|TIP|IMPORTANT|WARNING|CAUTION)s?[\]:][^:]?[ ]*(.*)$",
+    re.IGNORECASE
+)
 
-_RE_TYPED_ARGSTART = re.compile(r"([\w\[\]_]{1,}?)\s*?\((.*?)\):(.{2,})", re.IGNORECASE)
-_RE_ARGSTART = re.compile(r"(.{1,}?):(.{2,})", re.IGNORECASE)
+_RE_TYPED_ARGSTART = re.compile(r"^([\w\[\]_]{1,}?)[ ]*?\((.*?)\):[ ]+(.{2,})", re.IGNORECASE)
+_RE_ARGSTART = re.compile(r"^(.+):[ ]+(.{2,})$", re.IGNORECASE)
+
+_RE_CODE_TEXT = re.compile(r"^```[\w\-\.]*[ ]*$", re.IGNORECASE)
 
 _IGNORE_GENERATION_INSTRUCTION = "lazydocs: ignore"
 
@@ -361,106 +372,239 @@ def _doc2md(obj: Any) -> str:
     # doc = getdoc(func) or ""
     doc = _get_docstring(obj)
 
+    padding = 0
     blockindent = 0
-    argindent = 1
+    argindent = 0
     out = []
     arg_list = False
-    literal_block = False
+    section_block = False
+    block_exit = False
     md_code_snippet = False
-    quote_block = False
+    admonition_block = None
+    literal_block = None
+    doctest_block = None
+    prev_blank_line_count = 0
+    offset = 0
 
-    for line in doc.split("\n"):
+    @dataclass
+    class SectionBlock():
+        line_index: int
+        indent: int
+        offset: int
+
+    def _get_section_offset(lines: list, start_index: int, blockindent: int):
+        """Determine base padding offset for section.
+
+        Args:
+            lines (list): Line lists.
+            start_index (int): Index of lines to start parsing.
+            blockindent (int): Reference block indent of section.
+
+        Returns:
+            int: Padding offset.
+        """
+        offset = []
+        try:
+            for line in lines[start_index:]:
+                indent = len(line) - len(line.lstrip())
+                if not line.strip():
+                    continue
+                if indent <= blockindent:
+                    return -min(offset) if offset else 0
+                if indent > blockindent:
+                    offset.append(indent - blockindent)
+        except IndexError:
+            return 0
+        return -min(offset) if offset else 0
+
+    def _lines_isvalid(lines: list, start_index: int, blockindent: int,
+                            allow_same_level: bool = False,
+                            require_next_is_blank: bool = False,
+                            max_blank: int = None):
+        """Determine following lines fit section rules.
+
+        Args:
+            lines (list): Line lists.
+            start_index (int): Index of lines to start parsing.
+            blockindent (int): Reference block indent of section.
+            allow_same_level (bool, optional): Allow line indent as blockindent. Defaults to False.
+            require_next_is_blank (bool, optional): Require first parsed line to be blank. Defaults to False.
+            max_blank (int, optional): Max number of allowable continuous blank lines in section. Defaults to None.
+
+        Returns:
+            bool: Validity of tested lines.
+        """
+        prev_blank = 0
+        try:
+            for index, line in enumerate(lines[start_index:]):
+                indent = len(line) - len(line.lstrip())
+                line = line.strip()
+                if require_next_is_blank and index == 0 and line:
+                    return False
+                if line:
+                    prev_blank = 0
+                    if indent <= blockindent:
+                        if allow_same_level and indent == blockindent:
+                            return True
+                        return False
+                    return True
+                if max_blank is not None:
+                    if not line:
+                        prev_blank += 1
+                    if prev_blank > max_blank:
+                        return False
+        except IndexError:
+            pass
+        return False
+
+    docstring = doc.split("\n")
+    for line_indx, line in enumerate(docstring):
         indent = len(line) - len(line.lstrip())
-        if not md_code_snippet and not literal_block:
-            line = line.lstrip()
+        line = line.lstrip()
+        offset = 0
 
-        if line.startswith(">>>"):
-            # support for doctest
-            line = line.replace(">>>", "```") + "```"
+        # Exit condition for args and section blocks
+        if (any([arg_list, section_block])
+                and all([indent <= blockindent,
+                         prev_blank_line_count,
+                         line])):
+            arg_list = False if arg_list else arg_list
+            section_block = False if section_block else section_block
+            blockindent = 0
 
-        if (
-            _RE_BLOCKSTART_LIST.match(line)
-            or _RE_BLOCKSTART_TEXT.match(line)
-            or _RE_QUOTE_TEXT.match(line)
-        ):
+        admonition_result = _RE_ADMONITION_TEXT.match(line)
+        blockstart_result = _RE_BLOCKSTART_LIST.match(line)
+        blocktext_result = _RE_BLOCKSTART_TEXT.match(line)
+
+        if admonition_result and not (md_code_snippet or admonition_block):
+            # Admonition block entry condition
+            admonition_block = SectionBlock(
+                line_indx, indent, _get_section_offset(docstring,
+                                                       line_indx + 1,
+                                                       indent))
+            line = "[!{}] {}".format(admonition_result.group(1).upper(),
+                                     admonition_result.group(2))
+
+        # Entry conditions and block offsets
+        if _RE_CODE_TEXT.match(line):
+            # Code block, detect "```"
+            md_code_snippet = not md_code_snippet
+        elif line.startswith(">>>") and not doctest_block:
+            # Doctest Entry condition
+            line = "```python\n" + line
+            if _lines_isvalid(docstring, line_indx + 1, indent, True, False, 1):
+                doctest_block = SectionBlock(line_indx, indent, 0)
+                md_code_snippet = True
+            else:
+                line = line + "\n```"
+        elif doctest_block and \
+                not _lines_isvalid(docstring, line_indx + 1, doctest_block.indent,
+                                      True, False, 1):
+            # Doctest block Exit Condition
+            offset = doctest_block.indent - indent
+            line = " " * (indent - doctest_block.indent +
+                          doctest_block.offset) + line + "\n```"
+            block_exit = True
+        elif line.endswith("::") and not (literal_block) and \
+                _lines_isvalid(docstring, line_indx + 1, indent, False, True, None):
+            # Literal Block Entry Conditions
+            literal_block = SectionBlock(
+                line_indx, indent,
+                _get_section_offset(docstring, line_indx + 1, indent))
+            line = line.replace("::", "") if line.startswith(
+                "::") else line.replace("::", ":")
+            md_code_snippet = True
+        elif literal_block:
+            if line_indx == literal_block.line_index + 1 and not line:
+                # Literal block post entry
+                line = "```" + line
+                indent = literal_block.indent
+            elif not _lines_isvalid(docstring, line_indx + 1, literal_block.indent,
+                                       False, False, None):
+                # Literal block exit condition
+                offset += literal_block.indent - indent
+                line = " " * (indent - literal_block.indent +
+                              literal_block.offset) + line + "\n```"
+                block_exit = True
+            elif line:
+                offset += literal_block.offset
+
+        # Admonition block processing and exit condition
+        if admonition_block:
+            if md_code_snippet:
+                if literal_block:
+                    padding = max(indent - literal_block.indent, 0)
+                elif doctest_block:
+                    padding = max(indent - doctest_block.indent, 0)
+                else:
+                    padding = max(indent - admonition_block.indent
+                                  + admonition_block.offset, 0)
+                line = " " * (padding + offset) + line
+            offset = admonition_block.indent - indent
+            line = "> {}".format(line.replace("\n", "\n> "))
+            if not _lines_isvalid(docstring, line_indx + 1, admonition_block.indent,
+                                     False, False, None):
+                admonition_block = None
+
+        if (blockstart_result or blocktext_result):
             # start of a new block
             blockindent = indent
+            arg_list = bool(blockstart_result)
+            section_block = bool(blocktext_result)
 
-            if quote_block:
-                quote_block = False
-
-            if literal_block:
-                # break literal block
-                out.append("```\n")
-                literal_block = False
-
-            out.append("\n\n**{}**\n".format(line.strip()))
-
-            arg_list = bool(_RE_BLOCKSTART_LIST.match(line))
-
-            if _RE_QUOTE_TEXT.match(line):
-                quote_block = True
-                out.append("\n>")
-        elif line.strip().startswith("```"):
-            # Code snippet is used
-            if md_code_snippet:
-                md_code_snippet = False
-            else:
-                md_code_snippet = True
-
-            out.append(line)
-        elif line.strip().endswith("::"):
-            # Literal Block Support: https://docutils.sourceforge.io/docs/user/rst/quickref.html#literal-blocks
-            literal_block = True
-            out.append(line.replace("::", ":\n```"))
-        elif quote_block:
-            out.append(line.strip())
-        elif line.strip().startswith("-"):
-            # Allow bullet lists
-            out.append("\n" + (" " * indent) + line)
-        elif indent > blockindent:
+            if prev_blank_line_count <= 1:
+                out.append("\n")
+            out.append("**{}**\n".format(line.strip()))
+        elif indent > blockindent and (arg_list or section_block):
             if arg_list and not literal_block and _RE_TYPED_ARGSTART.match(line):
                 # start of new argument
                 out.append(
-                    "\n"
-                    + " " * blockindent
-                    + " - "
+                    "- "
                     + _RE_TYPED_ARGSTART.sub(r"<b>`\1`</b> (\2): \3", line)
                 )
                 argindent = indent
             elif arg_list and not literal_block and _RE_ARGSTART.match(line):
                 # start of an exception-type block
                 out.append(
-                    "\n"
-                    + " " * blockindent
-                    + " - "
+                    "- "
                     + _RE_ARGSTART.sub(r"<b>`\1`</b>: \2", line)
                 )
                 argindent = indent
             elif indent > argindent:
                 # attach docs text of argument
                 # * (blockindent + 2)
-                out.append(" " + line)
+                padding = max(indent - argindent + offset, 0)
+                out.append(" " * padding
+                           + line.replace("\n",
+                                          "\n" + " " * padding))
             else:
-                out.append(line)
+                padding = max(indent - blockindent + offset, 0)
+                out.append(line.replace("\n",
+                                        "\n" + " " * padding))
+        elif line:
+            padding = max(indent - blockindent + offset, 0)
+            out.append(" " * padding
+                       + line.replace("\n",
+                                      "\n" + " " * padding))
         else:
-            if line.strip() and literal_block:
-                # indent has changed, if not empty line, break literal block
-                line = "```\n" + line
-                literal_block = False
             out.append(line)
 
-        if md_code_snippet:
-            out.append("\n")
-        elif not line and not quote_block:
-            out.append("\n\n")
-        elif not line and quote_block:
-            out.append("\n>")
+        out.append("\n")
+
+        if block_exit:
+            block_exit = False
+            if md_code_snippet:
+                md_code_snippet = False
+            if literal_block:
+                literal_block = None
+            elif doctest_block:
+                doctest_block = None
+
+        if line.lstrip():
+            prev_blank_line_count = 0
         else:
-            out.append(" ")
-
+            prev_blank_line_count += 1
     return "".join(out)
-
 
 class MarkdownGenerator(object):
     """Markdown generator class."""

--- a/src/lazydocs/generation.py
+++ b/src/lazydocs/generation.py
@@ -624,6 +624,7 @@ class MarkdownGenerator(object):
         src_root_path: Optional[str] = None,
         src_base_url: Optional[str] = None,
         remove_package_prefix: bool = False,
+        url_line_prefix: Optional[str] = None,
     ):
         """Initializes the markdown API generator.
 
@@ -632,10 +633,12 @@ class MarkdownGenerator(object):
             src_base_url: The base github link. Should include branch name.
                 All source links are generated with this prefix.
             remove_package_prefix: If `True`, the package prefix will be removed from all functions and methods.
+            url_line_prefix: Line prefix for git repository line url anchors. Default: None - github "L".
         """
         self.src_root_path = src_root_path
         self.src_base_url = src_base_url
         self.remove_package_prefix = remove_package_prefix
+        self.url_line_prefix = url_line_prefix
 
         self.generated_objects: List[Dict] = []
 
@@ -677,7 +680,13 @@ class MarkdownGenerator(object):
         relative_path = os.path.relpath(path, src_root_path)
 
         lineno = _get_line_no(obj)
-        lineno_hashtag = "" if lineno is None else "#L{}".format(lineno)
+        if self.url_line_prefix is None:
+            lineno_hashtag = "" if lineno is None else "#L{}".format(lineno)
+        else:
+            lineno_hashtag = "" if lineno is None else "#{}{}".format(
+                self.url_line_prefix,
+                lineno
+            )
 
         # add line hash
         relative_path = relative_path + lineno_hashtag
@@ -1118,6 +1127,7 @@ def generate_docs(
     validate: bool = False,
     private_modules: bool = False,
     include_toc: bool = False,
+    url_line_prefix: Optional[str] = None,
 ) -> None:
     """Generates markdown documentation for provided paths based on Google-style docstrings.
 
@@ -1133,6 +1143,7 @@ def generate_docs(
         watermark: If `True`, add a watermark with a timestamp to bottom of the markdown files.
         validate: If `True`, validate the docstrings via pydocstyle. Requires pydocstyle to be installed.
         private_modules: If `True`, includes modules with `_` prefix.
+        url_line_prefix: Line prefix for git repository line url anchors. Default: None - github "L".
     """
     stdout_mode = output_path.lower() == "stdout"
 
@@ -1173,6 +1184,7 @@ def generate_docs(
         src_root_path=src_root_path,
         src_base_url=src_base_url,
         remove_package_prefix=remove_package_prefix,
+        url_line_prefix=url_line_prefix,
     )
 
     pydocstyle_cmd = "pydocstyle --convention=google --add-ignore=D100,D101,D102,D103,D104,D105,D107,D202"

--- a/src/lazydocs/generation.py
+++ b/src/lazydocs/generation.py
@@ -1011,8 +1011,13 @@ def generate_docs(
                     continue
 
                 try:
-                    mod_spec = loader.find_spec(module_name)
-                    mod = importlib.util.module_from_spec(mod_spec)
+                    try:
+                        mod_spec = importlib.util.spec_from_loader(module_name, loader)
+                        mod = importlib.util.module_from_spec(mod_spec)
+                        mod_spec.loader.exec_module(mod)
+                    except AttributeError:
+                        # For older python version compatibility
+                        mod = loader.find_module(module_name).load_module(module_name)  # type: ignore
                     module_md = generator.module2md(mod, is_mdx=is_mdx)
                     if not module_md:
                         # Module md is empty -> ignore module and all submodules
@@ -1090,8 +1095,13 @@ def generate_docs(
                             continue
 
                         try:
-                            mod_spec = loader.find_spec(module_name)
-                            mod = importlib.util.module_from_spec(mod_spec)
+                            try:
+                                mod_spec = importlib.util.spec_from_loader(module_name, loader)
+                                mod = importlib.util.module_from_spec(mod_spec)
+                                mod_spec.loader.exec_module(mod)
+                            except AttributeError:
+                                # For older python version compatibility
+                                mod = loader.find_module(module_name).load_module(module_name)  # type: ignore
                             module_md = generator.module2md(mod, is_mdx=is_mdx)
 
                             if not module_md:

--- a/src/lazydocs/generation.py
+++ b/src/lazydocs/generation.py
@@ -136,7 +136,10 @@ def _get_function_signature(
     if owner_class:
         name_parts.append(owner_class.__name__)
     if hasattr(function, "__name__"):
-        name_parts.append(function.__name__)
+        if function.__name__ == "__init__":
+            name_parts.append(_get_class_that_defined_method(function).__name__)
+        else:
+            name_parts.append(function.__name__)
     else:
         name_parts.append(type(function).__name__)
         name_parts.append("__call__")
@@ -735,7 +738,7 @@ class MarkdownGenerator(object):
                 func_type = "function"
             else:
                 # function of a class
-                func_type = "method"
+                func_type = "constructor" if escfuncname == "__init__" else "method"
 
         self.generated_objects.append(
             {

--- a/src/lazydocs/generation.py
+++ b/src/lazydocs/generation.py
@@ -12,6 +12,7 @@ import types
 from dataclasses import dataclass
 from pydoc import locate
 from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import quote
 
 _RE_BLOCKSTART_LIST = re.compile(
     r"^(Args:|Arg:|Arguments:|Parameters:|Kwargs:|Attributes:|Returns:|Yields:|Kwargs:|Raises:).{0,2}$",
@@ -683,7 +684,7 @@ class MarkdownGenerator(object):
         if append_base and self.src_base_url:
             relative_path = os.path.join(self.src_base_url, relative_path)
 
-        return relative_path
+        return quote("/".join(relative_path.split("\\")), safe=":/#")
 
     def func2md(self, func: Callable, clsname: str = "", depth: int = 3, is_mdx: bool = False) -> str:
         """Takes a function (or method) and generates markdown docs.

--- a/src/lazydocs/generation.py
+++ b/src/lazydocs/generation.py
@@ -211,16 +211,17 @@ def to_md_file(
     Args:
         markdown_str (str): Markdown string with line breaks to write to file.
         filename (str): Filename without the .md
+        out_path (str): The output directory.
         watermark (bool): If `True`, add a watermark with a timestamp to bottom of the markdown files.
         disable_markdownlint (bool): If `True`, an inline tag is added to disable markdownlint for this file.
-        out_path (str): The output directory
+        is_mdx (bool, optional): JSX support. Default to False.
     """
     if not markdown_str:
         # Dont write empty files
         return
 
     md_file = filename
-    
+
     if is_mdx:
         if not filename.endswith(".mdx"):
             md_file = filename + ".mdx"
@@ -538,6 +539,7 @@ class MarkdownGenerator(object):
             func (Callable): Selected function (or method) for markdown generation.
             clsname (str, optional): Class name to prepend to funcname. Defaults to "".
             depth (int, optional): Number of # to append to class name. Defaults to 3.
+            is_mdx (bool, optional): JSX support. Default to False.
 
         Returns:
             str: Markdown documentation for selected function.
@@ -614,7 +616,7 @@ class MarkdownGenerator(object):
         if path:
             if is_mdx:
                 markdown = _MDX_SOURCE_BADGE_TEMPLATE.format(path=path) + markdown
-            else:    
+            else:
                 markdown = _SOURCE_BADGE_TEMPLATE.format(path=path) + markdown
 
         return markdown
@@ -625,6 +627,7 @@ class MarkdownGenerator(object):
         Args:
             cls (class): Selected class for markdown generation.
             depth (int, optional): Number of # to append to function name. Defaults to 2.
+            is_mdx (bool, optional): JSX support. Default to False.
 
         Returns:
             str: Markdown documentation for selected class.
@@ -739,6 +742,7 @@ class MarkdownGenerator(object):
         Args:
             module (types.ModuleType): Selected module for markdown generation.
             depth (int, optional): Number of # to append before module heading. Defaults to 1.
+            is_mdx (bool, optional): JSX support. Default to False.
 
         Returns:
             str: Markdown documentation for selected module.
@@ -837,6 +841,7 @@ class MarkdownGenerator(object):
         Args:
             obj (Any): Selcted object for markdown docs generation.
             depth (int, optional): Number of # to append before heading. Defaults to 1.
+            is_mdx (bool, optional): JSX support. Default to False.
 
         Returns:
             str: Markdown documentation of selected object.
@@ -852,7 +857,14 @@ class MarkdownGenerator(object):
             return ""
 
     def overview2md(self, is_mdx: bool = False) -> str:
-        """Generates a documentation overview file based on the generated docs."""
+        """Generates a documentation overview file based on the generated docs.
+
+        Args:
+            is_mdx (bool, optional): JSX support. Default to False.
+
+        Returns:
+            str: Markdown documentation of overview file.
+        """
 
         entries_md = ""
         for obj in list(
@@ -935,6 +947,7 @@ def generate_docs(
         src_base_url: The base url of the github link. Should include branch name. All source links are generated with this prefix.
         remove_package_prefix: If `True`, the package prefix will be removed from all functions and methods.
         ignored_modules: A list of modules that should be ignored.
+        output_format: Markdown file extension and format.
         overview_file: Filename of overview file. If not provided, no overview file will be generated.
         watermark: If `True`, add a watermark with a timestamp to bottom of the markdown files.
         validate: If `True`, validate the docstrings via pydocstyle. Requires pydocstyle to be installed.


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [x] New Feature
- [x] Feature Improvment
- [ ] Refactoring
- [x] Documentation
- [ ] Other, please describe:

**Description:**
- Fixes generation of markdown files with no module functions rendered.
    - Caused by previous PR #57, forgetting to call on `mod_spec.loader.exec_module(mod)`
    - Inherently also fixed issue #69
- Overhauled docstring markdown rendering.
  - Markdown syntax should now be preserved.
    - #82
    - #83
  - doctest blocks should now render correctly, at least single blank lines to close blocks 
    - #79
    - #80
  - Literal blocks syntax and format is now same as reStructured text.
  - Fixes incorrect formatting due to the use of colon ":" in argument blocks.
        Line was not appending to parent argument, but appended on own line due to incorrect parsing as an argument.
  - Made code snippet \````\` detection more robust and less prone to false positives.
- Introduced support for Github flavoured admonitions block.
  - Converted from original quote blocks to admonition block
- Changed class constructor signature rendering.
  - Changed rendered type from method to constructor.
  - Changed signature of __init__ to class name, allows for easier understanding and implementation for new python users.
- Added feature to include private modules modules with "_" prefix
  - cli option: `--private-modules` and `--no-private-modules`. Defaults to `no-private-modules`
- Added feature for table of contents of functions generation in generated module markdown files.
  - cli option: `--toc` and `--no-toc`. Defaults to `no-toc`
- Fixed non-compliant url link format using incorrect backslash due to using os.path.join platform dependency. (#41)
  - Link is quoted to generate safe URL's.
- Added feature for user override of line anchors format to support different git hosting repo. (#74)
  - cli option: `--url-line-prefix TEXT`, defaults to None: which is github method of \#Lxxx
- Generated markdown file newlines is no longer platform dependent.
- Updated documentation and docstrings.
- Implemented crude work around to solve dataclass no attribute `__create_fn__` error (#72)
- Added support for dataclasses, enums and exceptions
- Updated pr-label.yml github work flow, sync-label from "" to false as workaround was fixed in labeler v5.0.0

**Checklist:**
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
